### PR TITLE
LogEvent autosave fix

### DIFF
--- a/generators/app/templates/infrastructure/src/plugins/logging/loggingUtils.js
+++ b/generators/app/templates/infrastructure/src/plugins/logging/loggingUtils.js
@@ -23,8 +23,8 @@ const shouldSkipLogging = (operationName, logLevel) => {
 }
 
 const initializeDbLogging = (context, operationName) => ({
-    logInfo: (message, code, autoSave = false) => shouldSkipLogging(operationName, loggingLevels.INFO) && logEvent(context, message, code, loggingLevels.INFO, autoSave),
-    logDebug: (message, code, autoSave = false) => shouldSkipLogging(operationName, loggingLevels.DEBUG) && logEvent(context, message, code, loggingLevels.DEBUG, autoSave),
+    logInfo: (message, code, autoSave = false) => shouldSkipLogging(operationName, loggingLevels.INFO) && logEvent(context, message, code, loggingLevels.INFO, null, autoSave),
+    logDebug: (message, code, autoSave = false) => shouldSkipLogging(operationName, loggingLevels.DEBUG) && logEvent(context, message, code, loggingLevels.DEBUG, null, autoSave),
     logError: (message, code, error) => shouldSkipLogging(operationName, loggingLevels.ERROR) && logDbError(context, message, code, loggingLevels.ERROR, error)
 })
 


### PR DESCRIPTION
LogEvent method was putting the autosave flag in error instead, therefore calling the logging method with autosave on true never actually saved the log. Now calling logEvent from logInfo & logDebug with 'null' for 'error' parameter.