### PR TITLE
Fix npm version for generated package.json

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -62,7 +62,7 @@ module.exports = class extends Generator {
         ignoreFiles
       )
 
-    const packageManagerVersion = packageManager === 'npm' ? '10.0.0' : packageManager === 'yarn' ? '1.22.4' : '10.0.0'
+    const packageManagerVersion = packageManager === 'npm' ? '7.16.0' : packageManager === 'yarn' ? '1.22.4' : '7.16.0'
 
     this.fs.copyTpl(
       templatePath,


### PR DESCRIPTION
The  packageManagerVersion  for npm was 10.0.0 which does not exist. It was replaced with the latest available version.