### PR TITLE
Downgrade mssql to ^6.2.0 to be compatible to knex

### DIFF
--- a/generators/app/templates/infrastructure/package.json
+++ b/generators/app/templates/infrastructure/package.json
@@ -77,7 +77,7 @@
     "koa-jwt": "^4.0.1",
     "lodash.merge": "^4.6.2",
     "mime-types": "^2.1.31",
-    "mssql": "^7.1.3",
+    "mssql": "^6.2.0",
     "node-nats-streaming": "0.3.2",
     <%_ if(addTracing){ _%>
     "opentracing": "^0.14.5",


### PR DESCRIPTION
Downgrade mssql to ^6.2.0 to be compatible to knex version ^0.21.19 from nodebb 
nodebb filters are incompatible with the latest knex version