### PR TITLE
removed default redis configs from helm/values.yaml

### DIFF
--- a/generators/app/templates/infrastructure/helm/gql/values.yaml
+++ b/generators/app/templates/infrastructure/helm/gql/values.yaml
@@ -72,8 +72,8 @@ gql:
   # Additional environment variables
   env:
 <%_ if(addSubscriptions) { _%>
-    REDIS_DOMAIN_NAME: "[REDIS_DOMAIN_NAME]"
-    REDIS_PORT_NUMBER: "[REDIS_PORT_NUMBER]"
+    REDIS_DOMAIN_NAME: ""
+    REDIS_PORT_NUMBER: ""
 <%_}_%>
     IDENTITY_API_URL: "[IDENTITY_API_URI]"
     IDENTITY_AUTHORITY: "[IDENTITY_AUTHORITY_URL]"


### PR DESCRIPTION
Removed from helm/values.yaml default configs for REDIS_DOMAIN_NAME and REDIS_PORT_NUMBER.
This was causing errors when deploying without explicit redis configuration