### PR TITLE
Change dataSource instance on every request 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@
 
 ## Installation  
   
-First, install [Yeoman](http://yeoman.io) and @totalsoft/generator-graphql-rocket using [npm V6.14.13](https://www.npmjs.com/) (we assume you have pre-installed [node.js >= V14.15](https://nodejs.org/)).
+First, install [Yeoman](http://yeoman.io) and @totalsoft/generator-graphql-rocket using [npm](https://www.npmjs.com/) (we assume you have pre-installed [NodeJS Latest LTS Version](https://nodejs.org/). Old versions of NodeJS are also supported.)
+
+>⚠ Use the npm version supported by your installed NodeJS version. 
+
+>e.g. NodeJS Latest LTS Version: 14.17.1 (includes npm 6.14.13)
   
 ```bash  
 npm install -g yo

--- a/generators/app/templates/infrastructure/src/index.js
+++ b/generators/app/templates/infrastructure/src/index.js
@@ -108,13 +108,14 @@ const server = new ApolloServer({
             if (!dbInstance) {
                 throw new TypeError("Could not create dbInstance. Check the database configuration info and restart the server.")
             }
+            const dataSources = getDataSources()
             return {
                 token,
                 <%_ if(addSubscriptions && withMultiTenancy){ _%>
                 tenant,
                 <%_}_%>
                 dbInstance,
-                dataSources: initializedDataSources(context, dbInstance),
+                dataSources: initializedDataSources(context, dbInstance, dataSources),
                 dataLoaders: getDataLoaders(dbInstance),
                 externalUser: {
                     id: decoded.sub,

--- a/generators/app/templates/infrastructure/src/startup/dataSources.js
+++ b/generators/app/templates/infrastructure/src/startup/dataSources.js
@@ -4,17 +4,15 @@ const UserDb = require('../features/user/dataSources/userDb');
 const TenantIdentityApi = require('../features/tenant/dataSources/tenantIdentityApi');
 <%_}_%>
 
-const ds = {
+module.exports.getDataSources = () => ({
     userApi: new UserApi(),
     userDb: new UserDb()<% if(withMultiTenancy){ %>,
     tenantIdentityApi: new TenantIdentityApi()
     <%_}_%>
-}
-
-module.exports.getDataSources = () => (ds)
+})
 
 // This is a temporary fix to pass dataSources to ws requests. This will be fixed in Apollo server v3.0
-module.exports.initializedDataSources = (context, dbInstance) => {
+module.exports.initializedDataSources = (context, dbInstance, dataSources) => {
     ds.userApi.initialize({ context })
     ds.userDb.initialize({ context: { dbInstance } })
     <%_ if(withMultiTenancy){ _%>


### PR DESCRIPTION
Fixes #54

Removed the ds constant from src/startup/dataSources.js, and initialize the ds object on every request. See Apollo Server documentation:
![image](https://user-images.githubusercontent.com/46926675/139075504-61342276-d93e-4e07-b5da-3c58ec2ae562.png)
