### PR TITLE
fix .env configs for prisma and knex

### DIFF
--- a/generators/app/templates/infrastructure/.env
+++ b/generators/app/templates/infrastructure/.env
@@ -18,18 +18,20 @@ REDIS_DOMAIN_NAME=""
 REDIS_PORT_NUMBER="6379"
 <%_}_%>
 
+<%_ if(dataLayer == 'knex') {_%>
 DB_HOST=""
 DB_PORT=""
 DB_USER=""
 DB_PASSWORD=""
 DB_DATABASE=""
 
+KNEX_LOGGING=true
+KNEX_DEBUG=false
+<%_}_%>
 <%_ if(addGqlLogging){ _%>
 # DEBUG, ERROR, INFO
 APOLLO_LOGGING_LEVEL=DEBUG
 <%_}_%>
-KNEX_LOGGING=true
-KNEX_DEBUG=false
 
 IDENTITY_API_URL=<%= identityApiUrl %>
 IDENTITY_AUTHORITY=<%= identityAuthority %>
@@ -44,6 +46,7 @@ JAEGER_SAMPLER_PARAM=1
 JAEGER_DISABLED=true
 <%_}_%>
 
+<%_ if(dataLayer == 'prisma') {_%>
 # This was inserted by `prisma init`:
 # Environment variables declared in this file are automatically made available to Prisma.
 # See the documentation for more detail: https://pris.ly/d/prisma-schema#using-environment-variables
@@ -52,3 +55,4 @@ JAEGER_DISABLED=true
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 DATABASE_URL="sqlserver://serverName:1433;database=databaseName;user=userName;password=password;trustServerCertificate=true"
 PRISMA_DEBUG=false
+<%_}_%>


### PR DESCRIPTION
remove prisma configs from .env when using knex and vice versa