### PR TITLE
update graphql to v16

### DIFF
--- a/generators/app/templates/infrastructure/package.json
+++ b/generators/app/templates/infrastructure/package.json
@@ -75,7 +75,7 @@
     <%_}_%>
     "apollo-datasource": "^3.3.2",
     "apollo-datasource-rest": "^3.6.1",
-    "apollo-server": "^3.10.0",
+    "apollo-server": "^3.11.1",
     "apollo-server-core": "^3.10.0",
     "apollo-server-koa": "^3.10.0",
     "async-mutex": "^0.3.2",
@@ -83,7 +83,7 @@
     "colors": "^1.4.0",
     "console-stamp": "^3.0.6",
     "dotenv": "16.0.1",
-    "graphql": "15.8.0",
+    "graphql": "16.6.0",
     <%_ if(addSubscriptions){ _%>
     "graphql-redis-subscriptions": "^2.5.0",
     "graphql-subscriptions": "^2.0.0",
@@ -93,14 +93,13 @@
     <%_}_%>
     <%_ if(withRights){ _%>
     "graphql-middleware": "^6.1.33",
-    "graphql-shield": "^7.5.0",
+    "graphql-shield": "7.6.4",
     <%_}_%>
     "graphql-upload": "^13.0.0",
     "humps": "^2.0.1",
     <%_ if(addTracing){ _%>
     "jaeger-client": "^3.19.0",
     "opentracing": "^0.14.7",
-    "apollo-opentracing": "^2.1.76",
     "@totalsoft/opentracing": "^1.1.0",
     "@totalsoft/pino-opentracing": "^1.1.0",
     <%_}_%>

--- a/generators/app/templates/infrastructure/src/middleware/permissions/__tests__/rules.tests.js
+++ b/generators/app/templates/infrastructure/src/middleware/permissions/__tests__/rules.tests.js
@@ -3,7 +3,7 @@ const {
     isAdmin,
     canViewDashboard
   } = require('../rules')
-  const { isRuleFunction } = require('graphql-shield/dist/utils')
+  const { isRuleFunction } = require('graphql-shield/esm/utils')
   
   describe('Test permission rules to be valid rule functions', () => {
     test('isAuthenticated is valid rule function', () => {

--- a/generators/app/templates/infrastructure/src/startup/schema.js
+++ b/generators/app/templates/infrastructure/src/startup/schema.js
@@ -16,7 +16,7 @@ const sources = loadTypedefsSync(join(__dirname, '../**/*.graphql'), {
   loaders: [new GraphQLFileLoader()]
 })
 const typeDefs = sources.map(source => source.document)
-const resolvers = mergeResolvers(join(__dirname, '../**/*resolvers.{js,ts}'), { globOptions: { caseSensitiveMatch: false } })
+const resolvers = mergeResolvers(loadFilesSync(join(__dirname, '../**/*resolvers.{js,ts}'), { globOptions: { caseSensitiveMatch: false } }))
 
 <%_ if(withRights){ _%>
 module.exports = applyMiddleware(makeExecutableSchema({ typeDefs, resolvers }), permissionsMiddleware)

--- a/generators/app/templates/infrastructure/src/subscriptions/extensibleSubscription.js
+++ b/generators/app/templates/infrastructure/src/subscriptions/extensibleSubscription.js
@@ -1,5 +1,5 @@
-const { default: isAsyncIterable } = require("graphql/jsutils/isAsyncIterable");
-const { default: mapAsyncIterator } = require("graphql/subscription/mapAsyncIterator");
+const { isAsyncIterable } = require("graphql/jsutils/isAsyncIterable");
+const { mapAsyncIterator } = require("graphql/execution/mapAsyncIterator");
 const { execute, createSourceEventStream, GraphQLError } = require("graphql");
 const { pipelineBuilder } = require("../utils/pipeline");
 
@@ -35,21 +35,6 @@ function subscribe({ middleware, filter }) {
           filter
         );
   };
-}
-/**
- * This function checks if the error is a GraphQLError. If it is, report it as
- * an ExecutionResult, containing only errors and no data. Otherwise treat the
- * error as a system-class error and re-throw it.
- */
-
-function reportGraphQLError(error) {
-  if (error instanceof GraphQLError) {
-    return {
-      errors: [error]
-    };
-  }
-
-  throw error;
 }
 
 function filterAsyncIterable(asyncIterable, predicate) {
@@ -118,8 +103,7 @@ function subscribeImpl(args, pipeline, filter) {
     return isAsyncIterable(resultOrStream)
       ? mapAsyncIterator(
           filter ? filterAsyncIterable(resultOrStream, filter(contextValue)) : resultOrStream,
-          mapSourceToResponse,
-          reportGraphQLError
+          mapSourceToResponse
         )
       : resultOrStream;
   });


### PR DESCRIPTION
- Upgrade graphql package to v16.x
- This upgrade comes with new versions for the following packages: 
   -> graphql-shield v7.6.4
   -> apollo-server v3.11.1
- Packages removed:
   -> apollo-opentracing
