### PR TITLE
Tracing resolver filter - only custom resolvers

### DIFF
--- a/generators/app/templates/infrastructure/src/startup/schema.js
+++ b/generators/app/templates/infrastructure/src/startup/schema.js
@@ -24,3 +24,6 @@ module.exports = applyMiddleware(makeExecutableSchema({ typeDefs, resolvers }), 
 module.exports = makeExecutableSchema({ typeDefs, resolvers });
 <%_}_%>
 module.exports.tests = { typeDefs, resolvers }
+module.exports.resolvers = resolvers;
+
+

--- a/generators/app/templates/infrastructure/src/tracing/gqlTracer.js
+++ b/generators/app/templates/infrastructure/src/tracing/gqlTracer.js
@@ -8,16 +8,11 @@ const initGqlTracer = ({ logger = console } = {}) => {
   return tracer
 }
 
-function _isPrimitive(value) {
-  if (value instanceof Date || value === null || value === undefined) return true
+function _shouldTraceFieldResolver({ info }) {
+  const { schema, parentType, path } = info || {};
 
-  return typeof value !== 'object'
-}
-
-function _shouldTraceFieldResolver({ source, info }) {
-  const isResolved = source && typeof source === 'object' && info.path.key in source
-  const isPrimitive = isResolved && _isPrimitive(source[info.path.key])
-  return !isResolved || !isPrimitive
+  const customResolver = schema?.resolvers[parentType?.name]?.[path?.key];
+  return Boolean(customResolver);
 }
 
 const _onRequestResolving = (span, _info) => {


### PR DESCRIPTION
OpenTracing generates too many spans for field resolvers. Modify the filter to generate spans for custom resolvers only.