### PR TITLE
Remove content type from apiRestDataSource

### DIFF
--- a/generators/app/templates/infrastructure/src/utils/apiRestDataSource.js
+++ b/generators/app/templates/infrastructure/src/utils/apiRestDataSource.js
@@ -28,7 +28,6 @@ class ApiRESTDataSource extends NoCacheRESTDataSource {
 
     const correlationId = correlationManager.getCorrelationId();
     if (correlationId) request.headers['x-correlation-id'] = correlationId
-      request.headers['content-type'] = 'application/json'
   }
 }
 


### PR DESCRIPTION
The content type is automatically set by RESTDataSource according to the body of the .
Setting it to "application/json" for all requests breaks file uploads which require a body of type FormData (content type "multipart/form-data")