### PR TITLE
add koaMiddleware separately, not chained to tracingMiddleware

### DIFF
--- a/generators/app/templates/infrastructure/src/servers/apollo.js
+++ b/generators/app/templates/infrastructure/src/servers/apollo.js
@@ -65,7 +65,7 @@ const startApolloServer = async (httpServer<% if(addSubscriptions) {%>, subscrip
       <%_ if(addTracing){ _%>
         tracingEnabled && app.use(tracingMiddleware())
       <%_}_%>
-        .use(
+      app.use(
         koaMiddleware(apolloServer,{
           context: async ({ ctx }) => {
             const { token, state, <% if(withMultiTenancy){ %>tenant, <%}%>externalUser, request, requestSpan } = ctx;


### PR DESCRIPTION
add koaMiddleware separately, not chained to tracingMiddleware so it will still be added even if tracingEnabled is false.